### PR TITLE
Fix premature printout of art exit status.

### DIFF
--- a/art/Framework/Art/art.cc.in
+++ b/art/Framework/Art/art.cc.in
@@ -1,25 +1,11 @@
 // vim: set sw=2 expandtab :
 
-#include <iostream>
-
-//================================================================
-// Make sure the exit code printer is executed just before the stdout
-// destructor by instantiating it afer the iostream include but before
-// any other include files, which might bring in their own static storage
-// duration objects.
+// Initialize ExitCodePrinter as early as possible, before
+// other include files, to have its destructor called as late as possible.
+#include "art/Framework/Art/detail/ExitCodePrinter.h"
 namespace {
-  int result;
-  bool print_completion_message = true;
-  struct ExitCodePrinter {
-    ~ExitCodePrinter() {
-      if(print_completion_message) {
-        std::cout << "Art has completed and will exit with status " << result << "." << std::endl;
-      }
-    }
-  };
-  ExitCodePrinter p;
+  art::detail::ExitCodePrinter p;
 }
-//================================================================
 
 #include "art/Framework/Art/artapp.h"
 #include "art/Framework/Art/detail/info_success.h"
@@ -31,10 +17,9 @@ using namespace std;
 int
 main(int argc, char* argv[])
 {
-  result = artapp(argc, argv);
+  p.result = artapp(argc, argv);
   mf::EndMessageFacility();
-  if (result == art::detail::info_success()) {
-    print_completion_message = false;
+  if (p.result == art::detail::info_success()) {
     return 0;
   }
 

--- a/art/Framework/Art/art.cc.in
+++ b/art/Framework/Art/art.cc.in
@@ -1,22 +1,43 @@
 // vim: set sw=2 expandtab :
+
+#include <iostream>
+
+//================================================================
+// Make sure the exit code printer is executed just before the stdout
+// destructor by instantiating it afer the iostream include but before
+// any other include files, which might bring in their own static storage
+// duration objects.
+namespace {
+  int result;
+  bool print_completion_message = true;
+  struct ExitCodePrinter {
+    ~ExitCodePrinter() {
+      if(print_completion_message) {
+        std::cout << "Art has completed and will exit with status " << result << "." << std::endl;
+      }
+    }
+  };
+  ExitCodePrinter p;
+}
+//================================================================
+
 #include "art/Framework/Art/artapp.h"
 #include "art/Framework/Art/detail/info_success.h"
 
 #include "messagefacility/MessageLogger/MessageLogger.h"
-
-#include <iostream>
 
 using namespace std;
 
 int
 main(int argc, char* argv[])
 {
-  int result = artapp(argc, argv);
+  result = artapp(argc, argv);
   mf::EndMessageFacility();
   if (result == art::detail::info_success()) {
+    print_completion_message = false;
     return 0;
   }
-  cout << "Art has completed and will exit with status " << result << "." << endl;
+
   return result;
 }
 

--- a/art/Framework/Art/detail/ExitCodePrinter.h
+++ b/art/Framework/Art/detail/ExitCodePrinter.h
@@ -1,0 +1,22 @@
+#ifndef art_Framework_Art_detail_ExitCodePrinter
+#define art_Framework_Art_detail_ExitCodePrinter
+
+#include "art/Framework/Art/detail/info_success.h"
+#include <iostream>
+
+namespace art::detail {
+  struct ExitCodePrinter {
+    int result = 0;
+    ~ExitCodePrinter() noexcept
+    {
+      if (result != info_success()) {
+        std::cout << "Art has completed and will exit with status " << result << "." << std::endl;
+      }
+    }
+  };
+}
+
+#endif
+// Local Variables:
+// mode: c++
+// End:


### PR DESCRIPTION
Hello,
I have seen cases of art jobs reporting success with the
 
   "Art has completed and will exit with status 0."

message and then crashing in a GEANT or ROOT destructor.
There is also https://github.com/art-framework-suite/art/issues/112
that is similar (but I think not as bad as the completion was not
reported as successful anyway).

This PR attempts to fix the premature exit status printout.
The idea is to move this printout from main() into a destructor of a static
object, and try to construct that object as early as possible, so that
its destructor will only be reached if other static destructors
did not cause problems.

Andrei
NB.  Mu2e has its own copy of the main art program; I am going to submit
a similar PR there if this one is accepted.