### PR TITLE
Handle full SQLite db for sqlite::Ntuple

### DIFF
--- a/art/Framework/Services/Optional/MemoryTrackerLinux_service.cc
+++ b/art/Framework/Services/Optional/MemoryTrackerLinux_service.cc
@@ -137,6 +137,7 @@ namespace art {
     void recordPeakUsages_();
     void flushTables_();
     void summary_();
+    bool anyTableFull_() const;
 
     LinuxProcMgr procInfo_{};
     string const fileName_;
@@ -425,15 +426,33 @@ namespace art {
     mf::LogAbsolute log{"MemoryTracker"};
     HorizontalRule const rule{100};
     log << '\n' << rule('=') << '\n';
-    log << std::left << "MemoryTracker summary (base-10 MB units used)\n\n";
-    log << "  Peak virtual memory usage (VmPeak)  : " << unique_value(rVMax)
-        << " MB\n"
-        << "  Peak resident set size usage (VmHWM): " << unique_value(rRMax)
-        << " MB\n";
-    if (!(fileName_.empty() || fileName_ == ":memory:")) {
-      log << "  Details saved in: '" << fileName_ << "'\n";
+
+    if (anyTableFull_()) {
+      log << "The SQLite database connected to the MemoryTracker exceeded the "
+             "available resources.\n";
+      log << "No memory usage summary is available.\n";
+      log << "The database at " << fileName_
+          << " will contain an incomplete record of this job's memory usage.\n";
+    } else {
+      log << std::left << "MemoryTracker summary (base-10 MB units used)\n\n";
+      log << "  Peak virtual memory usage (VmPeak)  : " << unique_value(rVMax)
+          << " MB\n"
+          << "  Peak resident set size usage (VmHWM): " << unique_value(rRMax)
+          << " MB\n";
+      if (!(fileName_.empty() || fileName_ == ":memory:")) {
+        log << "  Details saved in: '" << fileName_ << "'\n";
+      }
     }
     log << rule('=');
+  }
+
+  bool
+  MemoryTracker::anyTableFull_() const
+  {
+    return peakUsageTable_.full() || otherInfoTable_.full() ||
+           eventTable_.full() || moduleTable_.full() ||
+           (eventHeapTable_ && eventHeapTable_->full()) ||
+           (moduleHeapTable_ && moduleHeapTable_->full());
   }
 
 } // namespace art

--- a/art/Framework/Services/Optional/MemoryTrackerLinux_service.cc
+++ b/art/Framework/Services/Optional/MemoryTrackerLinux_service.cc
@@ -136,6 +136,7 @@ namespace art {
     bool checkMallocConfig_(string const&, bool);
     void recordPeakUsages_();
     void flushTables_();
+    bool using_file_database_() const;
     void summary_();
     bool anyTableFull_() const;
 
@@ -410,6 +411,12 @@ namespace art {
     }
   }
 
+  bool
+  MemoryTracker::using_file_database_() const
+  {
+    return !fileName_.empty() && fileName_ != ":memory:";
+  }
+
   void
   MemoryTracker::summary_()
   {
@@ -427,7 +434,7 @@ namespace art {
     HorizontalRule const rule{100};
     log << '\n' << rule('=') << '\n';
 
-    if (anyTableFull_()) {
+    if (anyTableFull_() && using_file_database_()) {
       log << "The SQLite database connected to the MemoryTracker exceeded the "
              "available resources.\n";
       log << "No memory usage summary is available.\n";
@@ -439,7 +446,7 @@ namespace art {
           << " MB\n"
           << "  Peak resident set size usage (VmHWM): " << unique_value(rRMax)
           << " MB\n";
-      if (!(fileName_.empty() || fileName_ == ":memory:")) {
+      if (using_file_database_()) {
         log << "  Details saved in: '" << fileName_ << "'\n";
       }
     }

--- a/art/Framework/Services/System/DatabaseConnection.h
+++ b/art/Framework/Services/System/DatabaseConnection.h
@@ -3,10 +3,12 @@
 // vim: set sw=2 expandtab :
 
 #include "art/Framework/Services/Registry/ServiceDeclarationMacros.h"
+#include "cetlib/sqlite/Connection.h"
 #include "cetlib/sqlite/ConnectionFactory.h"
 #include "cetlib/sqlite/detail/DefaultDatabaseOpenPolicy.h"
 #include "fhiclcpp/fwd.h"
 
+#include <memory>
 #include <string>
 #include <utility>
 
@@ -18,7 +20,7 @@ namespace art {
     template <typename DatabaseOpenPolicy =
                 cet::sqlite::detail::DefaultDatabaseOpenPolicy,
               typename... PolicyArgs>
-    cet::sqlite::Connection*
+    std::unique_ptr<cet::sqlite::Connection>
     get(std::string const& filename, PolicyArgs&&... policyArgs)
     {
       return factory_.make_connection<DatabaseOpenPolicy>(


### PR DESCRIPTION
Make it so that filling the database is not an error. Inserts and flushes of Ntuple become no-ops when a db becomes full.