### PR TITLE
Take advantage of new `make_waiting_task()` overloads

### DIFF
--- a/art/Framework/Core/TriggerPathsExecutor.cc
+++ b/art/Framework/Core/TriggerPathsExecutor.cc
@@ -232,9 +232,10 @@ namespace art {
         TDEBUG_END_FUNC_SI(4, scheduleID);
         return;
       }
-      auto pathsDoneTask = std::make_shared<WaitingTask>(
-        PathsDoneTask{this, endPathTask, event_principal, taskGroup_},
-        triggerPathsInfo_.paths().size());
+      auto pathsDoneTask =
+        make_waiting_task(
+          PathsDoneTask{this, endPathTask, event_principal, taskGroup_},
+          triggerPathsInfo_.paths().size());
       for (auto& path : triggerPathsInfo_.paths()) {
         // Start each path running.  The path will start a spawn chain
         // going to run each worker in the order specified on the


### PR DESCRIPTION
Requires https://github.com/art-framework-suite/hep-concurrency/pull/7.
